### PR TITLE
Add GlobalModelAccessFromEngine cop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in rubocop-flexport.gemspec
 gemspec
+
 gem 'rake'
 gem 'rspec'
 gem 'rubocop', github: 'rubocop-hq/rubocop'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,7 +1,7 @@
 Flexport/GlobalModelAccessFromEngine:
   Description: 'Do not directly access global models from within Rails Engines.'
   Enabled: false
-  VersionAdded: '2.4'
+  VersionAdded: '0.2.0'
   AutoCorrect: false
   EnginesPath: engines/
   GlobalModelsPath: app/models/

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,15 @@
+Flexport/GlobalModelAccessFromEngine:
+  Description: 'Do not directly access global models from within Rails Engines.'
+  Enabled: false
+  VersionAdded: '2.4'
+  AutoCorrect: false
+  EnginesPath: engines/
+  GlobalModelsPath: app/models/
+  DisabledEngines: []
+  AllowedGlobalModels: []
+  Include:
+    - '**/*.rb'
+
 Flexport/NewGlobalModel:
   Description: 'Disallows addition of new global models to `app/models`. Prefer Rails Engines or namespaces.'
   Enabled: true

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+require 'digest/sha1'
+
+module RuboCop
+  module Cop
+    module Flexport
+      # This cop checks for engines reaching directly into app/ models.
+      #
+      # With an ActiveRecord object, engine code can perform arbitrary
+      # reads and arbitrary writes to models located in the main `app/`
+      # directory. This cop helps isolate Rails Engine code to ensure
+      # that modular boundaries are respected.
+      #
+      # Checks for both access via `MyGlobalModel.foo` and associations.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class MyEngine::MyService
+      #     m = SomeGlobalModel.find(123)
+      #     m.any_random_attribute = "whatever i want"
+      #     m.save
+      #   end
+      #
+      #   # good
+      #
+      #   class MyEngine::MyService
+      #     ApiServiceForGlobalModels.perform_a_supported_operation("foo")
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class MyEngine::MyModel < ApplicationModel
+      #     has_one :some_global_model, class_name: "SomeGlobalModel"
+      #   end
+      #
+      #   # good
+      #
+      #   class MyEngine::MyModel < ApplicationModel
+      #     # No direct association to global models.
+      #   end
+      #
+      class GlobalModelAccessFromEngine < Cop
+        MSG = 'Direct access of global model from within Rails Engine.'
+
+        def_node_matcher :rails_association_hash_args, <<-PATTERN
+          (send _ {:belongs_to :has_one :has_many} sym $hash)
+        PATTERN
+
+        def on_const(node)
+          return unless in_enforced_engine_file?
+          return unless global_model_const?(node)
+          # The cop allows access to e.g. MyGlobalModel::MY_CONST.
+          return if child_of_const?(node)
+
+          add_offense(node)
+        end
+
+        def on_send(node)
+          return unless in_enforced_engine_file?
+
+          rails_association_hash_args(node) do |assocation_hash_args|
+            class_name_node = extract_class_name_node(assocation_hash_args)
+            class_name = class_name_node&.value
+            next unless global_model?(class_name)
+
+            add_offense(class_name_node)
+          end
+        end
+
+        # Because this cop's behavior depends on the state of external files,
+        # we override this method to bust the RuboCop cache when those files
+        # change.
+        def external_dependency_checksum
+          Digest::SHA1.hexdigest(model_dir_paths.join)
+        end
+
+        private
+
+        def global_model_names
+          @global_model_names ||= calculate_global_models
+        end
+
+        def model_dir_paths
+          Dir[File.join(global_models_path, '**/*.rb')]
+        end
+
+        def calculate_global_models
+          all_model_paths = model_dir_paths.reject do |path|
+            path.include?('/concerns/')
+          end
+          all_models = all_model_paths.map do |path|
+            # Translates `app/models/foo/bar_baz.rb` to `Foo::BarBaz`.
+            file_name = path.gsub(global_models_path, '').gsub('.rb', '')
+            ActiveSupport::Inflector.classify(file_name)
+          end
+          all_models - allowed_global_models
+        end
+
+        def extract_class_name_node(assocation_hash_args)
+          assocation_hash_args.each_pair do |key, value|
+            return value if key.value == :class_name && value.str_type?
+          end
+          nil
+        end
+
+        def in_enforced_engine_file?
+          file_path = processed_source.path
+          return false unless file_path.include?(engines_path)
+          return false if in_disabled_engine?(file_path)
+
+          true
+        end
+
+        def in_disabled_engine?(file_path)
+          disabled_engines.any? do |e|
+            file_path.include?(File.join(engines_path, e))
+          end
+        end
+
+        def global_model_const?(const_node)
+          # Remove leading `::`, if any.
+          class_name = const_node.source.sub(/^:*/, '')
+          global_model?(class_name)
+        end
+
+        # class_name is e.g. "FooGlobalModelNamespace::BarModel"
+        def global_model?(class_name)
+          global_model_names.include?(class_name)
+        end
+
+        def child_of_const?(node)
+          node.parent.const_type?
+        end
+
+        def global_models_path
+          path = cop_config['GlobalModelsPath']
+          path += '/' unless path.end_with?('/')
+          path
+        end
+
+        def engines_path
+          cop_config['EnginesPath']
+        end
+
+        def disabled_engines
+          raw = cop_config['DisabledEngines'] || []
+          raw.map do |e|
+            ActiveSupport::Inflector.underscore(e)
+          end
+        end
+
+        def allowed_global_models
+          cop_config['AllowedGlobalModels'] || []
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/flexport_cops.rb
+++ b/lib/rubocop/cop/flexport_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require_relative 'flexport/global_model_access_from_engine'
 require_relative 'flexport/new_global_model'

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end

--- a/rubocop-flexport.gemspec
+++ b/rubocop-flexport.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'rubocop', '>= 0.70.0'
 end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new(
+      'Flexport/GlobalModelAccessFromEngine' => {
+        'DisabledEngines' => %w[
+          fake_disabled_engine
+          FakeDisabledEngineCamel
+        ],
+        'EnginesPath' => 'engines',
+        'GlobalModelsPath' => 'app/models/',
+        'AllowedGlobalModels' => ['WhitelistedGlobalModel']
+      }
+    )
+  end
+
+  let(:engine_file) { '/root/engines/my_engine/app/file.rb' }
+
+  before do
+    allow(Dir).to(
+      receive(:[])
+        .with('app/models/**/*.rb')
+        .and_return([
+                      'app/models/some_global_model.rb',
+                      'app/models/nested/global_model.rb'
+                    ])
+    )
+  end
+
+  context 'no violation' do
+    describe 'disabled engine' do
+      let(:disabled_engine_file) do
+        '/root/engines/fake_disabled_engine/app/file.rb'
+      end
+      let(:source) do
+        <<~RUBY
+          SomeGlobalModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, disabled_engine_file)
+      end
+    end
+
+    describe 'disabled engine camel case' do
+      let(:disabled_engine_file) do
+        '/root/engines/fake_disabled_engine_camel/app/file.rb'
+      end
+      let(:source) do
+        <<~RUBY
+          SomeGlobalModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, disabled_engine_file)
+      end
+    end
+
+    describe 'just accessing a const' do
+      let(:source) do
+        <<~RUBY
+          a = SomeGlobalModel::SOME_CONST
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, engine_file)
+      end
+    end
+
+    describe 'file in app/ outside engine' do
+      let(:non_engine_file) { '/root/app/file.rb' }
+      let(:source) do
+        <<~RUBY
+          SomeGlobalModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, non_engine_file)
+      end
+    end
+
+    describe 'with whitelisted global model' do
+      let(:source) do
+        <<~RUBY
+          WhitelistedGlobalModel.find(123)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, engine_file)
+      end
+    end
+
+    describe 'association to global model in app/' do
+      let(:non_engine_file) { '/root/app/models/bar.rb' }
+      let(:source) do
+        <<~RUBY
+          class Bar < ApplicationModel
+            has_one :some_global_model, class_name: "SomeGlobalModel", inverse_of: :bar
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, non_engine_file)
+      end
+    end
+
+    describe 'association to other engine model' do
+      let(:source) do
+        <<~RUBY
+          class MyEngine::Foo < ApplicationModel
+            has_one :bar, class_name: "SomeOtherEngine::Bar", inverse_of: :foo
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, engine_file)
+      end
+    end
+  end
+
+  context 'violation' do
+    describe 'access of global model from engine' do
+      let(:source) do
+        <<~RUBY
+          SomeGlobalModel.find(123)
+          ^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source, engine_file)
+      end
+    end
+
+    describe 'association to global model' do
+      let(:source) do
+        <<~RUBY
+          class MyEngine::Foo < ApplicationModel
+            has_one :some_global_model, class_name: "SomeGlobalModel", inverse_of: :foo
+                                                    ^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+          end
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source, engine_file)
+      end
+    end
+
+    context 'nested global model' do
+      describe 'access of global model from engine' do
+        let(:source) do
+          <<~RUBY
+            Nested::GlobalModel.find(123)
+            ^^^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+          RUBY
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, engine_file)
+        end
+      end
+
+      describe 'association to global model' do
+        let(:source) do
+          <<~RUBY
+            class MyEngine::FooModel < ApplicationModel
+              has_one :nested_global_model, class_name: "Nested::GlobalModel", inverse_of: :foo
+                                                        ^^^^^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+            end
+          RUBY
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, engine_file)
+        end
+      end
+    end
+  end
+
+  describe '#external_dependency_checksum' do
+    it 'differs based on contents of app/models dir' do
+      old_checksum = cop.external_dependency_checksum
+      allow(Dir).to(
+        receive(:[])
+          .with('app/models/**/*.rb')
+          .and_return(['app/models/nested/global_model.rb'])
+      )
+      new_checksum = cop.external_dependency_checksum
+      expect(new_checksum).not_to equal(old_checksum)
+    end
+  end
+end


### PR DESCRIPTION
This cop prevents Rails Engines from directly accessing models in the main app/ directory.

A change in the main RuboCop repo is a prerequisite: "Allow cops to invalidate results cache" (rubocop-hq/rubocop#7496). In particular, this PR needs the Cop class to support the external_dependency_checksum method, which is proactively overridden here.