### PR TITLE
Add EngineApiBoundary cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,14 @@ Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
 
+Metrics/ClassLength:
+  Enabled: true
+  Max: 150
+
+Metrics/MethodLength:
+  Enabled: true
+  Max: 20
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-flexport.rb

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,9 +1,10 @@
-Flexport/EngineApiViolation:
+Flexport/EngineApiBoundary:
   Description: 'Use Rails Engine APIs instead of arbitrary code access.'
   Enabled: false
   VersionAdded: '0.3.0'
   EnginesPath: 'engines/'
   UnprotectedEngines: []
+  EngineSpecificOverrides: []
 
 Flexport/GlobalModelAccessFromEngine:
   Description: 'Do not directly access global models from within Rails Engines.'

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,10 @@
+Flexport/EngineApiViolation:
+  Description: 'Use Rails Engine APIs instead of arbitrary code access.'
+  Enabled: false
+  VersionAdded: '0.3.0'
+  EnginesPath: 'engines/'
+  UnprotectedEngines: []
+
 Flexport/GlobalModelAccessFromEngine:
   Description: 'Do not directly access global models from within Rails Engines.'
   Enabled: false

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Flexport
+      # This cop prevents code outside of a Rails Engine from directly
+      # accessing the engine without going through an API. The goal is
+      # to improve modularity and enforce separation of concerns.
+      #
+      # # Defining an engine's API
+      #
+      # The cop looks inside an engine's `api/` directory to determine its
+      # API. API surface can be defined in two ways:
+      #
+      # - Add source files to `api/`. Code defined in these modules
+      #   will be accessible outside your engine. For example, adding
+      #   `api/foo_service.rb` will allow code outside your engine to
+      #   invoke eg `MyEngine::Api::FooService.bar(baz)`.
+      # - Create a `_whitelist.rb` file in `api/`. Modules listed in
+      #   this file are accessible to code outside the engine. The file
+      #   must have this name and a particular format (see below).
+      #
+      # Both of these approaches can be used concurrently in the same engine.
+      # Due to Rails Engine directory conventions, the API directory should
+      # generally be located at eg `engines/my_engine/app/api/my_engine/api/`.
+      #
+      # # Usage
+      #
+      # This cop can be useful when splitting apart a legacy codebase.
+      # In particular, you might move some code into an engine without
+      # enabling the cop, and then enable the cop to see where the engine
+      # boundary is crossed. For each violation, you can either:
+      #
+      # - Expose new API surface from your engine
+      # - Move the violating file into the engine
+      # - Add the violating file to `_legacy_dependents.rb` (see below)
+      #
+      # The cop detects cross-engine associations as well as cross-engine
+      # module access.
+      #
+      # # Isolation guarantee
+      #
+      # This cop can be easily circumvented with metaprogramming, so it cannot
+      # strongly guarantee the isolation of engines. But it can serve as
+      # a useful guardrail during development, especially during incremental
+      # migrations.
+      #
+      # Consider using plain-old Ruby objects instead of ActiveRecords as the
+      # exchange value between engines. If one engine gets a reference to an
+      # ActiveRecord object for a model in another engine, it will be able
+      # to perform arbitrary reads and writes via associations and `.save`.
+      #
+      # # Example `api/_legacy_dependents.rb` file
+      #
+      # This file contains a burn-down list of source code files that still
+      # do direct access to an engine "under the hood", without using the
+      # API. It must have this structure.
+      #
+      # ```rb
+      # module MyEngine::Api::LegacyDependents
+      #   FILES_WITH_DIRECT_ACCESS = [
+      #     "app/models/some_old_legacy_model.rb",
+      #     "engines/other_engine/app/services/other_engine/other_service.rb",
+      #   ]
+      # end
+      # ```
+      #
+      # # Example `api/_whitelist.rb` file
+      #
+      # This file contains a list of modules that are allowed to be accessed
+      # by code outside the engine. It must have this structure.
+      #
+      # ```rb
+      # module MyEngine::Api::Whitelist
+      #   PUBLIC_MODULES = [
+      #     MyEngine::BarService,
+      #     MyEngine::BazService,
+      #     MyEngine::BatConstants,
+      #   ]
+      # end
+      # ```
+      #
+      # @example
+      #
+      #   # bad
+      #   class MyService
+      #     m = ReallyImportantSharedEngine::InternalModel.find(123)
+      #     m.destroy
+      #   end
+      #
+      #   # good
+      #   class MyService
+      #     ReallyImportantSharedEngine::Api::SomeService.execute(123)
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   class MyEngine::MyModel < ApplicationModel
+      #     has_one :foo_model, class_name: "SharedEngine::FooModel"
+      #   end
+      #
+      #   # good
+      #
+      #   class MyEngine::MyModel < ApplicationModel
+      #     # (No direct associations to models in API-protected engines.)
+      #   end
+      #
+      class EngineApiBoundary < Cop
+        include EngineApi
+
+        MSG = 'Direct access of %<engine>s engine. ' \
+              'Only access engine via %<engine>s::Api.'
+
+        def_node_matcher :rails_association_hash_args, <<-PATTERN
+          (send _ {:belongs_to :has_one :has_many} sym $hash)
+        PATTERN
+
+        def on_const(node)
+          # Sometimes modules/class are declared with the same name as an
+          # engine. For example, you might have:
+          #
+          #   /engines/foo
+          #   /app/graph/types/foo
+          #
+          # We ignore instead of yielding false positive for the module
+          # declaration in the latter.
+          return if in_module_or_class_declaration?(node)
+          # Similarly, you might have value objects that are named
+          # the same as engines like:
+          #
+          # Warehouse.new
+          #
+          # We don't want to warn on these cases either.
+          return if sending_method_to_namespace_itself?(node)
+
+          engine = extract_engine(node)
+          return unless engine
+          return if valid_engine_access?(node, engine)
+
+          add_offense(node, message: format(MSG, engine: engine))
+        end
+
+        def on_send(node)
+          rails_association_hash_args(node) do |assocation_hash_args|
+            class_name_node = extract_class_name_node(assocation_hash_args)
+            next if class_name_node.nil?
+
+            engine = extract_model_engine(class_name_node)
+            next if engine.nil?
+            next if valid_engine_access?(node, engine)
+
+            add_offense(class_name_node, message: format(MSG, engine: engine))
+          end
+        end
+
+        def external_dependency_checksum
+          engine_api_files_modified_time_checksum(engines_path)
+        end
+
+        private
+
+        def extract_engine(node)
+          return nil unless protected_engines.include?(node.const_name)
+
+          node.const_name
+        end
+
+        def engines_path
+          path = cop_config['EnginesPath']
+          path += '/' unless path.end_with?('/')
+          path
+        end
+
+        def protected_engines
+          @protected_engines ||= begin
+            unprotected = cop_config['UnprotectedEngines'] || []
+            unprotected_camelized = camelize_all(unprotected)
+            all_engines_camelized - unprotected_camelized
+          end
+        end
+
+        def all_engines_camelized
+          all_snake_case = Dir["#{engines_path}*"].map do |e|
+            e.gsub(engines_path, '')
+          end
+          camelize_all(all_snake_case)
+        end
+
+        def camelize_all(names)
+          names.map { |n| ActiveSupport::Inflector.camelize(n) }
+        end
+
+        def in_module_or_class_declaration?(node)
+          depth = 0
+          max_depth = 10
+          while node.const_type? && depth < max_depth
+            node = node.parent
+            depth += 1
+          end
+          node.module_type? || node.class_type?
+        end
+
+        def sending_method_to_namespace_itself?(node)
+          node.parent.send_type?
+        end
+
+        def valid_engine_access?(node, engine)
+          (
+            in_engine_file?(engine) ||
+            in_legacy_dependent_file?(engine) ||
+            through_api?(node) ||
+            whitelisted?(node, engine)
+          )
+        end
+
+        def extract_model_engine(class_name_node)
+          class_name = class_name_node.value
+          prefix = class_name.split('::')[0]
+          is_engine_model = prefix && protected_engines.include?(prefix)
+          is_engine_model ? prefix : nil
+        end
+
+        def extract_class_name_node(assocation_hash_args)
+          return nil unless assocation_hash_args
+
+          assocation_hash_args.each_pair do |key, value|
+            # Note: The "value.str_type?" is necessary because you can do this:
+            #
+            # TYPE_CLIENT = "Client".freeze
+            # belongs_to :recipient, class_name: TYPE_CLIENT
+            #
+            # The cop just ignores these cases. We could try to resolve the
+            # value of the const from the source but that seems brittle.
+            return value if key.value == :class_name && value.str_type?
+          end
+          nil
+        end
+
+        def current_engine
+          @current_engine ||= begin
+            file_path = processed_source.path
+            if file_path&.include?(engines_path)
+              parts = file_path.split(engines_path)
+              engine_dir = parts.last.split('/').first
+              ActiveSupport::Inflector.camelize(engine_dir) if engine_dir
+            end
+          end
+        end
+
+        def in_engine_file?(engine)
+          current_engine == engine
+        end
+
+        def in_legacy_dependent_file?(engine)
+          legacy_dependents = read_api_file(engine, :legacy_dependents)
+          # The file names are strings so we need to remove the escaped quotes
+          # on either side from the source code.
+          legacy_dependents = legacy_dependents.map do |source|
+            source.delete('"')
+          end
+          legacy_dependents.any? do |legacy_dependent|
+            processed_source.path.include?(legacy_dependent)
+          end
+        end
+
+        def through_api?(node)
+          node.parent&.const_type? && node.parent.children.last == :Api
+        end
+
+        def whitelisted?(node, engine)
+          whitelist = read_api_file(engine, :whitelist)
+          return false if whitelist.empty?
+
+          depth = 0
+          max_depth = 5
+          while node.const_type? && depth < max_depth
+            full_const_name = remove_leading_colons(node.source)
+            return true if whitelist.include?(full_const_name)
+
+            node = node.parent
+            depth += 1
+          end
+
+          false
+        end
+
+        def remove_leading_colons(str)
+          str.sub(/^:*/, '')
+        end
+
+        def read_api_file(engine, file_basename)
+          extract_api_list(engines_path, engine, file_basename)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/flexport_cops.rb
+++ b/lib/rubocop/cop/flexport_cops.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'mixin/engine_api'
+
+require_relative 'flexport/engine_api_boundary'
 require_relative 'flexport/global_model_access_from_engine'
 require_relative 'flexport/new_global_model'

--- a/lib/rubocop/cop/mixin/engine_api.rb
+++ b/lib/rubocop/cop/mixin/engine_api.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+require 'digest/sha1'
+
+module RuboCop
+  module Cop
+    # Functionality for reading Rails Engine API declaration files.
+    module EngineApi
+      extend NodePattern::Macros
+
+      API_FILE_DETAILS = {
+        whitelist: {
+          file_basename: '_whitelist.rb',
+          array_matcher: :whitelist_array
+        },
+        legacy_dependents: {
+          file_basename: '_legacy_dependents.rb',
+          array_matcher: :legacy_dependents_array
+        }
+      }.freeze
+
+      def extract_api_list(engines_path, engine, api_file)
+        key = cache_key(engine, api_file)
+        @cache ||= {}
+        cached = @cache[key]
+        return cached if cached
+
+        details = API_FILE_DETAILS[api_file]
+
+        path = full_path(engines_path, engine, details)
+        return [] unless File.file?(path)
+
+        list = extract_array(path, details[:array_matcher])
+
+        @cache[key] = list
+        list
+      end
+
+      def engine_api_files_modified_time_checksum(engines_path)
+        api_files = Dir.glob(File.join(engines_path, '**/app/api/**/api/**/*'))
+        mtimes = api_files.sort.map { |f| File.mtime(f) }
+        Digest::SHA1.hexdigest(mtimes.join)
+      end
+
+      private
+
+      def full_path(engines_path, engine, details)
+        api_path(engines_path, engine) + details[:file_basename]
+      end
+
+      def cache_key(engine, api_file)
+        "#{engine}-#{api_file}"
+      end
+
+      def api_path(engines_path, engine)
+        raw_name = ActiveSupport::Inflector.underscore(engine.to_s)
+        File.join(engines_path, "#{raw_name}/app/api/#{raw_name}/api/")
+      end
+
+      def parse_ast(file_path)
+        source_code = File.read(file_path)
+        source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
+        source.ast
+      end
+
+      def extract_module_root(path)
+        # The AST for the whitelist definition looks like this:
+        #
+        # (:module,
+        #   (:const,
+        #     (:const, nil, :Trucking), :Api),
+        #   (:casgn, nil, :PUBLIC_SERVICES,
+        #     (:array,
+        #       (:const,
+        #         s(:const, nil, :Trucking), :CancelDeliveryOrderService),
+        #       (:const,
+        #         s(:const, nil, :Trucking), :FclFulfillmentDetailsService))
+        #
+        # Or, in the case of two separate whitelists:
+        #
+        # (:module,
+        #   (:const,
+        #     (:const, nil, :Trucking), :Api),
+        #   s(:begin,
+        #     s(:casgn, nil, :PUBLIC_SERVICES,
+        #       s(:send,
+        #         s(:array,
+        #           s(:const,
+        #             s(:const, nil, :Trucking), :CancelDeliveryOrderService),
+        #           s(:const,
+        #             s(:const, nil, :Trucking), :ContainerUseService))),
+        #     s(:casgn, nil, :PUBLIC_CONSTANTS,
+        #       s(:send,
+        #         s(:array,
+        #           s(:const,
+        #             s(:const, nil, :Trucking), :DeliveryStatuses),
+        #           s(:const,
+        #             s(:const, nil, :Trucking), :LoadTypes)), :freeze)))
+        #
+        # We want the :begin in the 2nd case, the :module in the 1st case.
+        module_node = parse_ast(path)
+        module_block_node = module_node&.children&.[](1)
+        if module_block_node&.begin_type?
+          module_block_node
+        else
+          module_node
+        end
+      end
+
+      def_node_matcher :whitelist_array, <<-PATTERN
+          (casgn nil? {:PUBLIC_MODULES :PUBLIC_SERVICES :PUBLIC_CONSTANTS :PUBLIC_TYPES} {$array (send $array ...)})
+      PATTERN
+
+      def_node_matcher :legacy_dependents_array, <<-PATTERN
+          (casgn nil? {:FILES_WITH_DIRECT_ACCESS} {$array (send $array ...)})
+      PATTERN
+
+      def extract_array(path, array_matcher)
+        list = []
+        root_node = extract_module_root(path)
+        root_node.children.each do |module_child|
+          array_node = send(array_matcher, module_child)
+          next if array_node.nil?
+
+          array_node.children.map do |item|
+            list << item.source
+          end
+        end
+        list
+      end
+    end
+  end
+end

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.2.0'
+    VERSION = '0.3.0'
   end
 end

--- a/spec/rubocop/cop/engine_api_spec.rb
+++ b/spec/rubocop/cop/engine_api_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::EngineApi do
+  class TestEngineApi
+    include RuboCop::Cop::EngineApi
+  end
+
+  let(:cop) { TestEngineApi.new }
+
+  let(:engines_path) { 'engines/' }
+
+  let(:api_files) do
+    [
+      'engines/foo/app/api/foo/api/abc.rb',
+      'engines/foo/app/api/foo/api/_whitelist.rb',
+      'engines/bar/app/api/bar/api/def.rb'
+    ]
+  end
+
+  before do
+    allow(Dir).to(
+      receive(:glob)
+        .with('engines/**/app/api/**/api/**/*')
+        .and_return(api_files)
+    )
+    allow(File).to(
+      receive(:mtime)
+        .with(%r{app/api})
+        .and_return('2019-11-11 16:24:47 -0600')
+    )
+  end
+
+  describe '#engine_api_files_modified_time_checksum' do
+    it 'returns a string' do
+      result = cop.engine_api_files_modified_time_checksum(engines_path)
+      expect(result.is_a?(String)).to be(true)
+    end
+
+    context 'file modified time does not changes' do
+      it 'returns same checksum' do
+        first = cop.engine_api_files_modified_time_checksum(engines_path)
+        second = cop.engine_api_files_modified_time_checksum(engines_path)
+        expect(first).to eq(second)
+      end
+    end
+
+    context 'file modified time changes' do
+      it 'returns different checksum' do
+        old_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        allow(File).to(
+          receive(:mtime)
+            .with('engines/foo/app/api/foo/api/_whitelist.rb')
+            .and_return('2020-11-11 16:24:47 -0600')
+        )
+        new_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        expect(old_result).not_to eq(new_result)
+      end
+    end
+
+    context 'new file added' do
+      let(:new_file) do
+        'engines/bar/app/api/bar/api/_legacy_dependents.rb'
+      end
+
+      it 'returns different checksum' do
+        old_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        allow(Dir).to(
+          receive(:glob)
+            .with('engines/**/app/api/**/api/**/*')
+            .and_return(api_files.append(new_file))
+        )
+        new_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        expect(old_result).not_to eq(new_result)
+      end
+    end
+
+    context 'files are removed' do
+      let(:new_file) do
+        'engines/bar/app/api/bar/api/_legacy_dependents.rb'
+      end
+
+      it 'returns different checksum' do
+        old_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        allow(Dir).to(
+          receive(:glob)
+            .with('engines/**/app/api/**/api/**/*')
+            .and_return([api_files.first])
+        )
+        new_result = cop.engine_api_files_modified_time_checksum(engines_path)
+        expect(old_result).not_to eq(new_result)
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -1,0 +1,435 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new(
+      'Flexport/EngineApiBoundary' => config_params
+    )
+  end
+
+  let(:config_params) do
+    {
+      'UnprotectedEngines' => %w[
+        UnprotectedEngine
+        unprotected_engine_snake_case
+      ],
+      'EnginesPath' => 'engines'
+    }
+  end
+
+  let(:api_path) { 'engines/my_engine/app/api/my_engine/api/' }
+  let(:legacy_dependents_file) { api_path + '_legacy_dependents.rb' }
+  let(:whitelist_file) { api_path + '_whitelist.rb' }
+
+  before do
+    allow(File).to receive(:file?).and_call_original
+    allow(Dir).to(
+      receive(:[])
+        .with('engines/*')
+        .and_return([
+                      'engines/my_engine',
+                      'engines/other_engine',
+                      'engines/generic_name',
+                      'engines/unprotected_engine'
+                    ])
+    )
+    allow(File).to(
+      receive(:file?).with(/_legacy_dependents/).and_return(false)
+    )
+    allow(File).to(
+      receive(:file?).with(/_whitelist/).and_return(false)
+    )
+  end
+
+  context 'method call on the constant itself' do
+    context 'when constructor' do
+      let(:source) do
+        <<~RUBY
+          GenericName.new
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when random method' do
+      let(:source) do
+        <<~RUBY
+          GenericName.from_foo_bar
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when namepsaced not engine leading ::' do
+      let(:source) do
+        <<~RUBY
+          ::Types::GenericName.from_foo
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when namepsaced not engine' do
+      let(:source) do
+        <<~RUBY
+          Types::GenericName.from_foo
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+  end
+
+  context 'when going through interface' do
+    let(:source) do
+      <<~RUBY
+        class Controller < ApplicationController
+          def foo
+            MyEngine::Api.foo
+            MyEngine::Api::Nested.foo
+            EndsWithMyEngine::NoApi.foo
+            res = MyEngine::Api::NestedClass
+          end
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when module declaration' do
+    let(:source) do
+      <<~RUBY
+        module Mutations
+          module GenericName
+            module Foo
+              class Bar < Mutations::BaseMutation
+                def baz
+                  1
+                end
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when top-level module declaration' do
+    let(:source) do
+      <<~RUBY
+        module OtherEngine::Constants::Countries::Usa
+          FOO = "bar"
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when unprotected engine' do
+    let(:source) do
+      <<~RUBY
+        class Controller < ApplicationController
+          def foo
+            UnprotectedEngine::NoApi.foo
+          end
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when unprotected engine' do
+    let(:source) do
+      <<~RUBY
+        class Controller < ApplicationController
+          def foo
+            UnprotectedEngineSnakeCase::NoApi.foo
+          end
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when inside engine' do
+    let(:file) do
+      '/root/engines/my_engine/app/controllers/my_engine/foo_controller.rb'
+    end
+    let(:source) do
+      <<~RUBY
+        module MyEngine
+          class FooController
+          end
+        end
+        class MyEngine::NestedController < MyEngine::FooController
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source, file)
+    end
+  end
+
+  context 'when class has same name as engine' do
+    let(:source) do
+      <<~RUBY
+        module Foo
+          class MyEngine
+            def bar
+              1
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'when non-engine association' do
+    let(:source) do
+      <<~RUBY
+        class Foo < ApplicationModel
+          has_one :bar, class_name: "Bar", inverse_of: :foo
+        end
+      RUBY
+    end
+
+    it 'does not add any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
+  context 'Reaching into an engine' do
+    describe 'with no leading ::' do
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              MyEngine::Model.new
+              ^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              MyEngine::NoApi::Nested.foo
+              ^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              res = MyEngine::NestedClass
+                    ^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              MyEngine
+              ^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+            end
+          end
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source)
+      end
+    end
+
+    describe 'with leading ::' do
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              ::MyEngine::Model.new
+              ^^^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              ::MyEngine::NoApi::Nested.foo
+              ^^^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              res = ::MyEngine::NestedClass
+                    ^^^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+              ::MyEngine
+              ^^^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+            end
+          end
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source)
+      end
+    end
+
+    describe 'cross-engine association' do
+      let(:source) do
+        <<~RUBY
+          class Foo < ApplicationModel
+            has_one :delivery, class_name: "MyEngine::MyModel", inverse_of: :foo
+                                           ^^^^^^^^^^^^^^^^^^^ Direct access of MyEngine engine. Only access engine via MyEngine::Api.
+          end
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source)
+      end
+    end
+  end
+
+  context 'when whitelist defined' do
+    let(:whitelist_source) do
+      <<~RUBY
+        module MyEngine::Api::Whitelist
+          PUBLIC_MODULES = [
+            MyEngine::WhitelistedModule,
+          ]
+        end
+      RUBY
+    end
+
+    before do
+      allow(File).to(
+        receive(:file?)
+          .with(whitelist_file)
+          .and_return(true)
+      )
+      allow(File).to(
+        receive(:read)
+          .with(whitelist_file)
+          .and_return(whitelist_source)
+      )
+    end
+
+    context 'when whitelisted public service' do
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              MyEngine::WhitelistedModule.bar
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when whitelisted public constant' do
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              MyEngine::WhitelistedModule::CRUX
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when whitelisted method accessed with leading :: and expect' do
+      let(:source) do
+        <<~RUBY
+          expect(::MyEngine::WhitelistedModule).to_not receive(:foo)
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+
+    context 'when whitelisted public constant in array' do
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              if [
+                MyEngine::WhitelistedModule::NOT_MANIFESTED,
+              ]
+                1
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source)
+      end
+    end
+  end
+
+  context 'when whitelist defined' do
+    let(:legacy_dependents_source) do
+      <<~RUBY
+        module MyEngine::Api::LegacyDependents
+          FILES_WITH_DIRECT_ACCESS = [
+            "app/models/some_old_legacy_model.rb",
+            "engines/other_engine/app/services/other_engine/other_service.rb",
+          ]
+        end
+      RUBY
+    end
+
+    before do
+      allow(File).to(
+        receive(:file?)
+          .with(legacy_dependents_file)
+          .and_return(true)
+      )
+      allow(File).to(
+        receive(:read)
+          .with(legacy_dependents_file)
+          .and_return(legacy_dependents_source)
+      )
+    end
+
+    context 'when in legacy dependent file' do
+      let(:file) { '/root/app/models/some_old_legacy_model.rb' }
+      let(:source) do
+        <<~RUBY
+          class Controller < ApplicationController
+            def foo
+              MyEngine::SomethingPrivateFoo.bar
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, file)
+      end
+    end
+  end
+
+  describe '#external_dependency_checksum' do
+    it 'returns a string' do
+      expect(cop.external_dependency_checksum.is_a?(String)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
This cop enforces modular isolation of Rails Engines. It allows engines to define an API surface in an internal `api/` directory. Code outside the engine is only allowed to interact with the engine through that API surface. For more details, check out in the class comments in `engine_api_boundary.rb`.

Whereas `Flexport/GlobalModelAccessFromEngine` prevents an engine from reaching _out_ into the global `app/models`, this cop prevents any code outside an engine from reaching _in_ to access that engine.

A change in the main RuboCop repo is a prerequisite for this PR: "Allow cops to invalidate results cache" (rubocop-hq/rubocop#7496).