### PR TITLE
Add comments and specs for NewGlobalModel in repo with multiple Rails services

### DIFF
--- a/lib/rubocop/cop/flexport/new_global_model.rb
+++ b/lib/rubocop/cop/flexport/new_global_model.rb
@@ -12,6 +12,12 @@ module RuboCop
       # Use RuboCop's standard `Exclude` file list parameter to exclude
       # existing global model files from counting as violations for this cop.
       #
+      # If you have a monorepo with multiple Rails services, you may wish to
+      # set GlobalModelsPath to something more specific than `app/models` so
+      # that it only matches the main monolith service and allows global
+      # models in other, smaller services. To do this, just set GlobalModelsPath
+      # to e.g. `flexport/app/models` in your `.rubocop.yml`.
+      #
       # @example AllowNamespacedGlobalModels: true (default)
       #   # When `AllowNamespacedGlobalModels` is true, the cop only forbids
       #   # additions at the top-level directory.

--- a/spec/rubocop/cop/flexport/new_global_model_spec.rb
+++ b/spec/rubocop/cop/flexport/new_global_model_spec.rb
@@ -126,4 +126,52 @@ RSpec.describe RuboCop::Cop::Flexport::NewGlobalModel do
       end
     end
   end
+
+  context 'monorepo fullpath' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Flexport/NewGlobalModel' => {
+          'GlobalModelsPath' => 'flexport/app/models/',
+          'AllowNamespacedGlobalModels' => true
+        }
+      )
+    end
+
+    context 'when new global model file in monolith' do
+      let(:global_model_file) do
+        '/root/flexport/app/models/new_global_model.rb'
+      end
+
+      let(:source) do
+        <<~RUBY
+          class NewGlobalModel
+          ^^^^^^^^^^^^^^^^^^^^ Do not add new top-level global models in `app/models`. Prefer namespaced models like `app/models/foo/bar.rb` or or models inside Rails Engines.
+            FOO = 1
+          end
+        RUBY
+      end
+
+      it 'adds offenses' do
+        expect_offense(source, global_model_file)
+      end
+    end
+
+    context 'when new global model file in other service' do
+      let(:global_model_file) do
+        '/root/other_service/rails/app/models/new_global_model.rb'
+      end
+
+      let(:source) do
+        <<~RUBY
+          class NewModelInOtherService
+            FOO = 1
+          end
+        RUBY
+      end
+
+      it 'adds offenses' do
+        expect_no_offenses(source, global_model_file)
+      end
+    end
+  end
 end


### PR DESCRIPTION
We want this cop to be enforced in the Rails monolith service but not on other Rails services in the monorepo. This comment and the specs ensure support for that case.