### PR TITLE
Show global model name in warning

### DIFF
--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -46,7 +46,8 @@ module RuboCop
       #   end
       #
       class GlobalModelAccessFromEngine < Cop
-        MSG = 'Direct access of global model from within Rails Engine.'
+        MSG = 'Direct access of global model `%<model>s` ' \
+              'from within Rails Engine.'
 
         def_node_matcher :rails_association_hash_args, <<-PATTERN
           (send _ {:belongs_to :has_one :has_many} sym $hash)
@@ -58,7 +59,7 @@ module RuboCop
           # The cop allows access to e.g. MyGlobalModel::MY_CONST.
           return if child_of_const?(node)
 
-          add_offense(node)
+          add_offense(node, message: message(node.source))
         end
 
         def on_send(node)
@@ -69,7 +70,7 @@ module RuboCop
             class_name = class_name_node&.value
             next unless global_model?(class_name)
 
-            add_offense(class_name_node)
+            add_offense(class_name_node, message: message(class_name))
           end
         end
 
@@ -81,6 +82,10 @@ module RuboCop
         end
 
         private
+
+        def message(model)
+          format(MSG, model: model)
+        end
 
         def global_model_names
           @global_model_names ||= calculate_global_models

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
       let(:source) do
         <<~RUBY
           SomeGlobalModel.find(123)
-          ^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+          ^^^^^^^^^^^^^^^ Direct access of global model `SomeGlobalModel` from within Rails Engine.
         RUBY
       end
 
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
         <<~RUBY
           class MyEngine::Foo < ApplicationModel
             has_one :some_global_model, class_name: "SomeGlobalModel", inverse_of: :foo
-                                                    ^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+                                                    ^^^^^^^^^^^^^^^^^ Direct access of global model `SomeGlobalModel` from within Rails Engine.
           end
         RUBY
       end
@@ -162,7 +162,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
         let(:source) do
           <<~RUBY
             Nested::GlobalModel.find(123)
-            ^^^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+            ^^^^^^^^^^^^^^^^^^^ Direct access of global model `Nested::GlobalModel` from within Rails Engine.
           RUBY
         end
 
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
           <<~RUBY
             class MyEngine::FooModel < ApplicationModel
               has_one :nested_global_model, class_name: "Nested::GlobalModel", inverse_of: :foo
-                                                        ^^^^^^^^^^^^^^^^^^^^^ Direct access of global model from within Rails Engine.
+                                                        ^^^^^^^^^^^^^^^^^^^^^ Direct access of global model `Nested::GlobalModel` from within Rails Engine.
             end
           RUBY
         end


### PR DESCRIPTION
Previously, the cop `Flexport/GlobalModelAccessFromEngine` would only show a generic message and you'd have to look at the source line to see which model was was being used. This change shows the model name.

Before:

```
Direct access of global model from within Rails Engine.
```

After:

```
Direct access of global model `SomeGlobalModel` from within Rails Engine.
```
