### PR TITLE
Don't warn if node in_module_or_class_declaration in GlobalModelAccessFromEngine

### DIFF
--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -109,6 +109,7 @@ module RuboCop
       #
       class EngineApiBoundary < Cop
         include EngineApi
+        include EngineNodeContext
 
         MSG = 'Direct access of %<engine>s engine. ' \
               'Only access engine via %<engine>s::Api.'
@@ -118,16 +119,8 @@ module RuboCop
         PATTERN
 
         def on_const(node)
-          # Sometimes modules/class are declared with the same name as an
-          # engine. For example, you might have:
-          #
-          #   /engines/foo
-          #   /app/graph/types/foo
-          #
-          # We ignore instead of yielding false positive for the module
-          # declaration in the latter.
           return if in_module_or_class_declaration?(node)
-          # Similarly, you might have value objects that are named
+          # There might be value objects that are named
           # the same as engines like:
           #
           # Warehouse.new
@@ -190,16 +183,6 @@ module RuboCop
 
         def camelize_all(names)
           names.map { |n| ActiveSupport::Inflector.camelize(n) }
-        end
-
-        def in_module_or_class_declaration?(node)
-          depth = 0
-          max_depth = 10
-          while node.const_type? && depth < max_depth
-            node = node.parent
-            depth += 1
-          end
-          node.module_type? || node.class_type?
         end
 
         def sending_method_to_namespace_itself?(node)

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -46,6 +46,8 @@ module RuboCop
       #   end
       #
       class GlobalModelAccessFromEngine < Cop
+        include EngineNodeContext
+
         MSG = 'Direct access of global model `%<model>s` ' \
               'from within Rails Engine.'
 
@@ -58,6 +60,7 @@ module RuboCop
           return unless global_model_const?(node)
           # The cop allows access to e.g. MyGlobalModel::MY_CONST.
           return if child_of_const?(node)
+          return if in_module_or_class_declaration?(node)
 
           add_offense(node, message: message(node.source))
         end

--- a/lib/rubocop/cop/flexport_cops.rb
+++ b/lib/rubocop/cop/flexport_cops.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'mixin/engine_api'
+require_relative 'mixin/engine_node_context'
 
 require_relative 'flexport/engine_api_boundary'
 require_relative 'flexport/global_model_access_from_engine'

--- a/lib/rubocop/cop/mixin/engine_node_context.rb
+++ b/lib/rubocop/cop/mixin/engine_node_context.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_support/inflector'
-require 'digest/sha1'
-
 module RuboCop
   module Cop
     # Helpers for determining the context of a node for engine violations.

--- a/lib/rubocop/cop/mixin/engine_node_context.rb
+++ b/lib/rubocop/cop/mixin/engine_node_context.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'active_support/inflector'
+require 'digest/sha1'
+
+module RuboCop
+  module Cop
+    # Helpers for determining the context of a node for engine violations.
+    module EngineNodeContext
+      # Sometimes modules/class are declared with the same name as an
+      # engine or global model. For example, you might have both:
+      #
+      #   /engines/foo
+      #   /app/graph/types/foo
+      #
+      # We ignore instead of yielding false positive for the module
+      # declaration in the latter.
+      def in_module_or_class_declaration?(node)
+        depth = 0
+        max_depth = 10
+        while node.const_type? && depth < max_depth
+          node = node.parent
+          depth += 1
+        end
+        node.module_type? || node.class_type?
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -31,6 +31,25 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
   end
 
   context 'no violation' do
+    describe 'many nested modules' do
+      let(:source) do
+        <<~RUBY
+          module MyEngine
+            module Errors
+              module SomeGlobalModel
+                class SomeClientError
+                end
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'does not add any offenses' do
+        expect_no_offenses(source, engine_file)
+      end
+    end
+
     describe 'disabled engine' do
       let(:disabled_engine_file) do
         '/root/engines/fake_disabled_engine/app/file.rb'


### PR DESCRIPTION
Fixes a bug in `GlobalModelAccessFromEngine` very similar to a bug that had been previously fixed in `EngineApiBoundary` by moving sharing logic to a mixin.

![image](https://user-images.githubusercontent.com/1289501/72665313-c6d23d00-39cc-11ea-9046-ff8de49f73f3.png)
