### PR TITLE
Fix bug related to engines with similar names being incorrectly disabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+## 0.8.0
+
+- Bug fix related to disabling engines with similar names.
 
 ## 0.7.0
 

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -127,6 +127,8 @@ module RuboCop
 
         def in_disabled_engine?(file_path)
           disabled_engines.any? do |e|
+            # Add trailing / to engine path to avoid incorrectly
+            # matching engines with similar names
             file_path.include?(File.join(engines_path, e, ''))
           end
         end

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -127,7 +127,7 @@ module RuboCop
 
         def in_disabled_engine?(file_path)
           disabled_engines.any? do |e|
-            file_path.include?(File.join(engines_path, e))
+            file_path.include?(File.join(engines_path, e, ''))
           end
         end
 

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
       it 'adds an offense' do
         expect_offense(source, engine_file)
       end
+
+      context "an engine's name has a prefix that matches a disabled engine" do
+        let(:engine_file) do
+          '/root/engines/fake_disabled_engine_foo/app/file.rb'
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, engine_file)
+        end
+      end
     end
 
     describe 'association to global model' do


### PR DESCRIPTION
If an engine's name had a prefix that exactly matched that of a disabled engine, the engine would be incorrectly disabled.