### PR TITLE
Add allowlist as optional whitelist alternative in engine boundary rubocop

### DIFF
--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   will be accessible outside your engine. For example, adding
       #   `api/foo_service.rb` will allow code outside your engine to
       #   invoke eg `MyEngine::Api::FooService.bar(baz)`.
-      # - Create a `_whitelist.rb` file in `api/`. Modules listed in
+      # - Create an `allowlist.rb` or `_whitelist.rb` file in `api/`. Modules listed in
       #   this file are accessible to code outside the engine. The file
       #   must have this name and a particular format (see below).
       #
@@ -268,7 +268,8 @@ module RuboCop
           (
             in_legacy_dependent_file?(accessed_engine) ||
             through_api?(node) ||
-            whitelisted?(node, accessed_engine)
+            whitelisted?(node, accessed_engine) ||
+            allowlisted?(node, accessed_engine)
           )
         end
 
@@ -324,6 +325,23 @@ module RuboCop
 
         def through_api?(node)
           node.parent&.const_type? && node.parent.children.last == :Api
+        end
+
+        def allowlisted?(node, engine)
+          allowlist = read_api_file(engine, :allowlist)
+          return false if allowlist.empty?
+
+          depth = 0
+          max_depth = 5
+          while node.const_type? && depth < max_depth
+            full_const_name = remove_leading_colons(node.source)
+            return true if allowlist.include?(full_const_name)
+
+            node = node.parent
+            depth += 1
+          end
+
+          false
         end
 
         def whitelisted?(node, engine)

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -328,9 +328,7 @@ module RuboCop
 
         def allowlisted?(node, engine)
           allowlist = read_api_file(engine, :allowlist)
-          if allowlist.empty?
-            allowlist = read_api_file(engine, :whitelist)
-          end
+          allowlist = read_api_file(engine, :whitelist) if allowlist.empty?
           return false if allowlist.empty?
 
           depth = 0

--- a/lib/rubocop/cop/mixin/engine_api.rb
+++ b/lib/rubocop/cop/mixin/engine_api.rb
@@ -10,9 +10,13 @@ module RuboCop
       extend NodePattern::Macros
 
       API_FILE_DETAILS = {
+        allowlist: {
+          file_basename: '_allowlist.rb',
+          array_matcher: :allowlist_array
+        },
         whitelist: {
           file_basename: '_whitelist.rb',
-          array_matcher: :whitelist_array
+          array_matcher: :allowlist_array
         },
         legacy_dependents: {
           file_basename: '_legacy_dependents.rb',
@@ -108,7 +112,7 @@ module RuboCop
         end
       end
 
-      def_node_matcher :whitelist_array, <<-PATTERN
+      def_node_matcher :allowlist_array, <<-PATTERN
           (casgn nil? {:PUBLIC_MODULES :PUBLIC_SERVICES :PUBLIC_CONSTANTS :PUBLIC_TYPES} {$array (send $array ...)})
       PATTERN
 


### PR DESCRIPTION
Step 1 in transitioning from whitelist -> allowlist. This PR should allow teams to slowly rename their files with no breaking changes. After each team has fully migrated off using whitelist in their engine APIs, we can remove the whitelist usage here.