### PR TITLE
Bump version to 0.9.0 and add changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## 0.9.0
+
+- Add support for `_allowlist.rb`, in addition to `_whitelist.rb`.
+
 ## 0.8.0
 
 - Bug fix related to disabling engines with similar names.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ like below and then run `bundle install`:
 gem "rubocop-flexport", path: "/Users/<user>/rubocop-flexport"
 ```
 
-To release a new version, update the version number in `version.rb`, and then
+To release a new version, update the version number in `lib/rubocop/flexport/version.rb`, and then
 run `bundle exec rake release`, which will create a git tag for the version,
 push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.8.0'
+    VERSION = '0.9.0'
   end
 end


### PR DESCRIPTION
Quick follow-up to https://github.com/flexport/rubocop-flexport/pull/19.