### PR TITLE
Warn on cross-engine FactoryBot usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+## 0.10.0
+
+- EngineApiBoundary cop detects cross-engine use of FactoryBoy factories.
+- GlobalModelAccessFromEngine cop detects use of global FactoryBoy factories.
+
 ## 0.9.0
 
 - Add support for `_allowlist.rb`, in addition to `_whitelist.rb`.

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -444,7 +444,7 @@ module RuboCop
           self.class.factory_engines_cache ||= spec_factory_paths.each_with_object({}) do |path, h|
             engine_name = engine_name_from_path(path)
             ast = parse_ast(path)
-            find_factories(ast).each do |factory|
+            find_factories(ast).each do |factory, _|
               h[factory] = engine_name
             end
           end

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'digest/sha1'
+
 # rubocop:disable Metrics/ClassLength
 module RuboCop
   module Cop
@@ -38,6 +40,11 @@ module RuboCop
       #
       # The cop detects cross-engine associations as well as cross-engine
       # module access.
+      #
+      # The cop will complain if you use FactoryBot factories defined in other
+      # engines in your engine's specs. You can disable this check by adding
+      # the engine name to `AllowCrossEngineFactoryBotFromEngines` in
+      # .rubocop.yml.
       #
       # # Isolation guarantee
       #
@@ -141,6 +148,7 @@ module RuboCop
       class EngineApiBoundary < Cop
         include EngineApi
         include EngineNodeContext
+        include FactoryBotMixin
 
         MSG = 'Direct access of %<accessed_engine>s engine. ' \
               'Only access engine via %<accessed_engine>s::Api.'
@@ -179,19 +187,40 @@ module RuboCop
 
         def on_send(node)
           rails_association_hash_args(node) do |assocation_hash_args|
-            class_name_node = extract_class_name_node(assocation_hash_args)
-            next if class_name_node.nil?
+            check_for_cross_engine_rails_association(node, assocation_hash_args)
+          end
+          return unless should_check_for_cross_engine_factory_bot?
 
-            accessed_engine = extract_model_engine(class_name_node)
-            next if accessed_engine.nil?
-            next if valid_engine_access?(node, accessed_engine)
-
-            add_offense(class_name_node, message: message(accessed_engine))
+          factory_bot(node) do |factory_node|
+            check_for_cross_engine_factory_bot_usage(node, factory_node)
           end
         end
 
+        def check_for_cross_engine_rails_association(node, assocation_hash_args)
+          class_name_node = extract_class_name_node(assocation_hash_args)
+          return if class_name_node.nil?
+
+          accessed_engine = extract_model_engine(class_name_node)
+          return if accessed_engine.nil?
+          return if valid_engine_access?(node, accessed_engine)
+
+          add_offense(class_name_node, message: message(accessed_engine))
+        end
+
+        def check_for_cross_engine_factory_bot_usage(node, factory_node)
+          factory = factory_node.children[0]
+          accessed_engine = factory_engines[factory]
+          return if accessed_engine.nil?
+          return if valid_engine_access?(node, accessed_engine)
+
+          add_offense(node, message: message(accessed_engine))
+        end
+
         def external_dependency_checksum
-          engine_api_files_modified_time_checksum(engines_path)
+          checksum = engine_api_files_modified_time_checksum(engines_path)
+          return checksum unless should_check_for_cross_engine_factory_bot?
+
+          checksum + spec_factories_modified_time_checksum
         end
 
         private
@@ -296,14 +325,15 @@ module RuboCop
         end
 
         def current_engine
-          @current_engine ||= begin
-            file_path = processed_source.path
-            if file_path&.include?(engines_path)
-              parts = file_path.split(engines_path)
-              engine_dir = parts.last.split('/').first
-              ActiveSupport::Inflector.camelize(engine_dir) if engine_dir
-            end
-          end
+          @current_engine ||= engine_name_from_path(processed_source.path)
+        end
+
+        def engine_name_from_path(file_path)
+          return nil unless file_path&.include?(engines_path)
+
+          parts = file_path.split(engines_path)
+          engine_dir = parts.last.split('/').first
+          ActiveSupport::Inflector.camelize(engine_dir) if engine_dir
         end
 
         def in_engine_file?(accessed_engine)
@@ -392,6 +422,35 @@ module RuboCop
 
         def strongly_protected_engine?(engine)
           strongly_protected_engines.include?(engine)
+        end
+
+        def allow_cross_engine_factory_bot_from_engines
+          @allow_cross_engine_factory_bot_from_engines ||=
+            camelize_all(cop_config['AllowCrossEngineFactoryBotFromEngines'] || [])
+        end
+
+        def should_check_for_cross_engine_factory_bot?
+          spec_file? && !allow_cross_engine_factory_bot_from_engines.include?(current_engine)
+        end
+
+        # Maps factories to the engine where they are defined.
+        def factory_engines
+          @factory_engines ||= spec_factory_paths.each_with_object({}) do |path, h|
+            engine_name = engine_name_from_path(path)
+            ast = parse_ast(path)
+            find_factories(ast).each do |factory|
+              h[factory] = engine_name
+            end
+          end
+        end
+
+        def spec_factory_paths
+          @spec_factory_paths ||= Dir["#{engines_path}*/spec/factories/**/*.rb"]
+        end
+
+        def spec_factories_modified_time_checksum
+          mtimes = spec_factory_paths.sort.map { |f| File.mtime(f) }
+          Digest::SHA1.hexdigest(mtimes.join)
         end
       end
     end

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -168,6 +168,10 @@ module RuboCop
           (send _ {:belongs_to :has_one :has_many} sym $hash)
         PATTERN
 
+        class << self
+          attr_accessor :factory_engines_cache
+        end
+
         def on_const(node)
           return if in_module_or_class_declaration?(node)
           # There might be value objects that are named
@@ -435,7 +439,9 @@ module RuboCop
 
         # Maps factories to the engine where they are defined.
         def factory_engines
-          @factory_engines ||= spec_factory_paths.each_with_object({}) do |path, h|
+          # Cache factories at the class level so that we don't have to fetch
+          # them again for every file we lint.
+          self.class.factory_engines_cache ||= spec_factory_paths.each_with_object({}) do |path, h|
             engine_name = engine_name_from_path(path)
             ast = parse_ast(path)
             find_factories(ast).each do |factory|

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -193,7 +193,7 @@ module RuboCop
           rails_association_hash_args(node) do |assocation_hash_args|
             check_for_cross_engine_rails_association(node, assocation_hash_args)
           end
-          return unless should_check_for_cross_engine_factory_bot?
+          return unless check_for_cross_engine_factory_bot?
 
           factory_bot_usage(node) do |factory_node|
             check_for_cross_engine_factory_bot_usage(node, factory_node)
@@ -224,7 +224,7 @@ module RuboCop
 
         def external_dependency_checksum
           checksum = engine_api_files_modified_time_checksum(engines_path)
-          return checksum unless should_check_for_cross_engine_factory_bot?
+          return checksum unless check_for_cross_engine_factory_bot?
 
           checksum + spec_factories_modified_time_checksum
         end
@@ -435,7 +435,7 @@ module RuboCop
             camelize_all(cop_config['AllowCrossEngineFactoryBotFromEngines'] || [])
         end
 
-        def should_check_for_cross_engine_factory_bot?
+        def check_for_cross_engine_factory_bot?
           spec_file? && !allow_cross_engine_factory_bot_from_engines.include?(current_engine)
         end
 

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -191,7 +191,7 @@ module RuboCop
           end
           return unless should_check_for_cross_engine_factory_bot?
 
-          factory_bot(node) do |factory_node|
+          factory_bot_usage(node) do |factory_node|
             check_for_cross_engine_factory_bot_usage(node, factory_node)
           end
         end

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -148,7 +148,7 @@ module RuboCop
       class EngineApiBoundary < Cop
         include EngineApi
         include EngineNodeContext
-        include FactoryBotMixin
+        include FactoryBotUsage
 
         MSG = 'Direct access of %<accessed_engine>s engine. ' \
               'Only access engine via %<accessed_engine>s::Api.'

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -123,7 +123,7 @@ module RuboCop
           self.class.global_factories_cache ||= spec_factory_paths.flat_map do |path|
             source_code = File.read(path)
             source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
-            find_factories(source.ast)
+            find_factories(source.ast).map { |factory, _| factory }
           end
         end
 

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -82,7 +82,7 @@ module RuboCop
             check_for_rails_association_with_global_model(assocation_hash_args)
           end
 
-          return unless should_check_for_global_factory_bot?
+          return unless check_for_global_factory_bot?
 
           factory_bot_usage(node) do |factory_node|
             check_for_global_factory_bot_usage(node, factory_node)
@@ -109,7 +109,7 @@ module RuboCop
         # we override this method to bust the RuboCop cache when those files
         # change.
         def external_dependency_checksum
-          if should_check_for_global_factory_bot?
+          if check_for_global_factory_bot?
             Digest::SHA1.hexdigest((model_dir_paths + global_factories.keys.sort).join)
           else
             Digest::SHA1.hexdigest(model_dir_paths.join)
@@ -181,7 +181,7 @@ module RuboCop
           end
         end
 
-        def should_check_for_global_factory_bot?
+        def check_for_global_factory_bot?
           spec_file? && allow_global_factory_bot_from_engines.none? do |engine|
             processed_source.path.include?(File.join(engines_path, engine, ''))
           end

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -52,7 +52,7 @@ module RuboCop
       #
       class GlobalModelAccessFromEngine < Cop
         include EngineNodeContext
-        include FactoryBotMixin
+        include FactoryBotUsage
 
         MSG = 'Direct access of global model `%<model>s` ' \
               'from within Rails Engine.'

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -45,8 +45,14 @@ module RuboCop
       #     # No direct association to global models.
       #   end
       #
+      # This cop will also complain if you try to use global FactoryBot
+      # factories in your engine's specs. To disable this behavior for your
+      # engine, add it to the `AllowGlobalFactoryBotFromEngines` list in
+      # .rubocop.yml.
+      #
       class GlobalModelAccessFromEngine < Cop
         include EngineNodeContext
+        include FactoryBotMixin
 
         MSG = 'Direct access of global model `%<model>s` ' \
               'from within Rails Engine.'
@@ -75,13 +81,26 @@ module RuboCop
 
             add_offense(class_name_node, message: message(class_name))
           end
+
+          return unless should_check_for_cross_engine_factory_bot?
+
+          factory_bot(node) do |factory_node|
+            factory = factory_node.children[0]
+            next unless global_factory?(factory)
+
+            add_offense(node, message: message(factory))
+          end
         end
 
         # Because this cop's behavior depends on the state of external files,
         # we override this method to bust the RuboCop cache when those files
         # change.
         def external_dependency_checksum
-          Digest::SHA1.hexdigest(model_dir_paths.join)
+          if should_check_for_cross_engine_factory_bot?
+            Digest::SHA1.hexdigest((model_dir_paths + global_factories.sort).join)
+          else
+            Digest::SHA1.hexdigest(model_dir_paths.join)
+          end
         end
 
         private
@@ -94,8 +113,20 @@ module RuboCop
           @global_model_names ||= calculate_global_models
         end
 
+        def global_factories
+          @global_factories ||= spec_factory_paths.flat_map do |path|
+            source_code = File.read(path)
+            source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
+            find_factories(source.ast)
+          end
+        end
+
         def model_dir_paths
           Dir[File.join(global_models_path, '**/*.rb')]
+        end
+
+        def spec_factory_paths
+          @spec_factory_paths ||= Dir['spec/factories/**/*.rb']
         end
 
         def calculate_global_models
@@ -133,6 +164,12 @@ module RuboCop
           end
         end
 
+        def should_check_for_cross_engine_factory_bot?
+          spec_file? && allow_global_factory_bot_from_engines.none? do |engine|
+            processed_source.path.include?(File.join(engines_path, engine, ''))
+          end
+        end
+
         def global_model_const?(const_node)
           # Remove leading `::`, if any.
           class_name = const_node.source.sub(/^:*/, '')
@@ -142,6 +179,10 @@ module RuboCop
         # class_name is e.g. "FooGlobalModelNamespace::BarModel"
         def global_model?(class_name)
           global_model_names.include?(class_name)
+        end
+
+        def global_factory?(factory_name)
+          global_factories.include?(factory_name)
         end
 
         def child_of_const?(node)
@@ -163,6 +204,10 @@ module RuboCop
           raw.map do |e|
             ActiveSupport::Inflector.underscore(e)
           end
+        end
+
+        def allow_global_factory_bot_from_engines
+          cop_config['AllowGlobalFactoryBotFromEngines'] || []
         end
 
         def allowed_global_models

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -84,7 +84,7 @@ module RuboCop
 
           return unless should_check_for_cross_engine_factory_bot?
 
-          factory_bot(node) do |factory_node|
+          factory_bot_usage(node) do |factory_node|
             factory = factory_node.children[0]
             next unless global_factory?(factory)
 

--- a/lib/rubocop/cop/flexport_cops.rb
+++ b/lib/rubocop/cop/flexport_cops.rb
@@ -2,7 +2,7 @@
 
 require_relative 'mixin/engine_api'
 require_relative 'mixin/engine_node_context'
-require_relative 'mixin/factory_bot_mixin'
+require_relative 'mixin/factory_bot_usage'
 
 require_relative 'flexport/engine_api_boundary'
 require_relative 'flexport/global_model_access_from_engine'

--- a/lib/rubocop/cop/flexport_cops.rb
+++ b/lib/rubocop/cop/flexport_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'mixin/engine_api'
 require_relative 'mixin/engine_node_context'
+require_relative 'mixin/factory_bot_mixin'
 
 require_relative 'flexport/engine_api_boundary'
 require_relative 'flexport/global_model_access_from_engine'

--- a/lib/rubocop/cop/mixin/engine_api.rb
+++ b/lib/rubocop/cop/mixin/engine_api.rb
@@ -62,8 +62,7 @@ module RuboCop
         File.join(engines_path, "#{raw_name}/app/api/#{raw_name}/api/")
       end
 
-      def parse_ast(file_path)
-        source_code = File.read(file_path)
+      def parse_ast(source_code)
         source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
         source.ast
       end
@@ -103,7 +102,7 @@ module RuboCop
         #             s(:const, nil, :Trucking), :LoadTypes)), :freeze)))
         #
         # We want the :begin in the 2nd case, the :module in the 1st case.
-        module_node = parse_ast(path)
+        module_node = parse_ast(File.read(path))
         module_block_node = module_node&.children&.[](1)
         if module_block_node&.begin_type?
           module_block_node

--- a/lib/rubocop/cop/mixin/factory_bot_mixin.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_mixin.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Helpers for detecting FactoryBot usage.
+    module FactoryBotMixin
+      extend NodePattern::Macros
+
+      def_node_matcher :factory_bot, <<~PATTERN
+        (send _ {:build :build_list :create :create_list} $sym)
+      PATTERN
+
+      def spec_file?
+        processed_source&.path&.match?(/_spec\.rb$/) || false
+      end
+
+      # Recursively traverses a Parser::AST::Node, returning an array of all
+      # the factory names found within.
+      def find_factories(node)
+        factories = []
+        return factories unless node.is_a?(Parser::AST::Node)
+
+        if node.type == :send && node.children[1] == :factory
+          factory_name_node = node.children[2]
+          factory_name = factory_name_node.children[0]
+          factories << factory_name
+        end
+
+        factories + node.children.flat_map { |child| find_factories(child) }
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/inflector'
+
 module RuboCop
   module Cop
     # Helpers for detecting FactoryBot usage.
@@ -27,19 +29,83 @@ module RuboCop
         processed_source&.path&.match?(/_spec\.rb$/) || false
       end
 
-      # Recursively traverses a Parser::AST::Node, returning an array of all
-      # the factory names found within.
-      def find_factories(node)
+      # Recursively traverses a Parser::AST::Node, returning an array of
+      # [factory_name, model_class_name] 2-tuples.
+      def find_factories(node, model_class_name = nil)
         factories = []
         return factories unless node.is_a?(Parser::AST::Node)
 
-        if node.type == :send && node.children[1] == :factory
-          factory_name_node = node.children[2]
-          factory_name = factory_name_node.children[0]
-          factories << factory_name
+        factory_node = extract_factory_node(node)
+        if factory_node
+          factory_name, aliases, model_class_name = parse_factory_node(factory_node, model_class_name)
+          if factory_node?(node)
+            ([factory_name] + aliases).each do |name|
+              factories << [name, model_class_name]
+            end
+          end
         end
 
-        factories + node.children.flat_map { |child| find_factories(child) }
+        factories + node.children.flat_map { |child| find_factories(child, model_class_name) }
+      end
+
+      private
+
+      def extract_factory_node(node)
+        return node.children[0] if factory_block?(node)
+        return node if factory_node?(node)
+      end
+
+      def factory_block?(node)
+        return false if node&.type != :block
+
+        factory_node?(node.children[0])
+      end
+
+      def factory_node?(node)
+        node&.type == :send && node.children[1] == :factory
+      end
+
+      def parse_factory_node(node, model_class_name_from_parent_factory = nil)
+        factory_name_node, factory_config_node = node.children[2..3]
+
+        factory_name = factory_name_node.children[0]
+        aliases = extract_aliases(factory_config_node)
+        explicit_model_class_name = extract_model_class_name(factory_config_node)
+        model_class_name = explicit_model_class_name ||
+                           model_class_name_from_parent_factory ||
+                           ActiveSupport::Inflector.camelize(factory_name)
+
+        [factory_name, aliases, model_class_name]
+      end
+
+      def extract_aliases(factory_config_hash_node)
+        aliases_array = extract_hash_value(factory_config_hash_node, :aliases)
+        return [] if aliases_array&.type != :array
+
+        aliases_array.children.map(&:value)
+      end
+
+      def extract_model_class_name(factory_config_hash_node)
+        model_class_name_node = extract_hash_value(factory_config_hash_node, :class)
+
+        case model_class_name_node&.type
+        when :const
+          model_class_name_node.source.sub(/^::/, '')
+        when :str
+          model_class_name_node.value.sub(/^::/, '')
+        end
+      end
+
+      def extract_hash_value(node, hash_key)
+        return nil if node&.type != :hash
+
+        pairs = node.children.select { |child| child.type == :pair }
+        pairs.each do |pair|
+          key, value = pair.children
+          return value if key.value == hash_key
+        end
+
+        nil
       end
     end
   end

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -19,7 +19,7 @@ module RuboCop
         create_pair
       ].freeze
 
-      def_node_matcher :factory_bot, <<~PATTERN
+      def_node_matcher :factory_bot_usage, <<~PATTERN
         (send _ {#{FACTORY_BOT_METHODS.map(&:inspect).join(' ')}} $sym)
       PATTERN
 

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     # Helpers for detecting FactoryBot usage.
-    module FactoryBotMixin
+    module FactoryBotUsage
       extend NodePattern::Macros
 
       def_node_matcher :factory_bot, <<~PATTERN

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -6,8 +6,21 @@ module RuboCop
     module FactoryBotUsage
       extend NodePattern::Macros
 
+      FACTORY_BOT_METHODS = %i[
+        attributes_for
+        attributes_for_list
+        build
+        build_list
+        build_pair
+        build_stubbed
+        build_stubbed_list
+        create
+        create_list
+        create_pair
+      ].freeze
+
       def_node_matcher :factory_bot, <<~PATTERN
-        (send _ {:build :build_list :create :create_list} $sym)
+        (send _ {#{FACTORY_BOT_METHODS.map(&:inspect).join(' ')}} $sym)
       PATTERN
 
       def spec_file?

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.9.0'
+    VERSION = '0.10.0'
   end
 end

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -345,6 +345,13 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
           .and_return(factory)
       end
 
+      # We cache factories at the class level, so that we don't have to compute
+      # them again for every file. Clear the cache after each test to ensure we
+      # run each test with a clean slate.
+      after do
+        described_class.factory_engines_cache = nil
+      end
+
       context 'when file is not a spec' do
         let(:file_path) { 'engines/my_engine/lib/foo.rb' }
 

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
           let(:source) do
             <<~RUBY
               create(:port)
-              ^^^^^^^^^^^^^ Direct access of global model `port` from within Rails Engine.
+              ^^^^^^^^^^^^^ Direct access of global model `Port` from within Rails Engine.
             RUBY
           end
 

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -212,6 +212,13 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
           .and_return(factory)
       end
 
+      # We cache factories at the class level, so that we don't have to compute
+      # them again for every file. Clear the cache after each test to ensure we
+      # run each test with a clean slate.
+      after do
+        described_class.global_factories_cache = nil
+      end
+
       context 'when file is not a spec' do
         it 'does not add any offenses' do
           expect_no_offenses(source, engine_file)

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -186,6 +186,72 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
       end
     end
 
+    describe 'using global spec factories from engine' do
+      let(:factory_path) { 'spec/factories/port.rb' }
+      let(:factory) do
+        <<~RUBY
+          FactoryBot.define do
+            factory :port
+          end
+        RUBY
+      end
+      let(:source) do
+        <<~RUBY
+          create(:port)
+        RUBY
+      end
+
+      before do
+        allow(Dir)
+          .to receive(:[])
+          .with('spec/factories/**/*.rb')
+          .and_return([factory_path])
+        allow(File)
+          .to receive(:read)
+          .with(factory_path)
+          .and_return(factory)
+      end
+
+      context 'when file is not a spec' do
+        it 'does not add any offenses' do
+          expect_no_offenses(source, engine_file)
+        end
+      end
+
+      context 'when file is a spec' do
+        let(:engine_file) { '/root/engines/my_engine/spec/foo_spec.rb' }
+
+        context 'when engine is not in the allowed list' do
+          let(:source) do
+            <<~RUBY
+              create(:port)
+              ^^^^^^^^^^^^^ Direct access of global model `port` from within Rails Engine.
+            RUBY
+          end
+
+          it 'adds an offense' do
+            expect_offense(source, engine_file)
+          end
+        end
+
+        context 'when engine is in the allowed list' do
+          let(:config) do
+            RuboCop::Config.new(
+              'Flexport/GlobalModelAccessFromEngine' => {
+                'EnginesPath' => 'engines',
+                'GlobalModelsPath' => 'app/models/',
+                'AllowGlobalFactoryBotFromEngines' => ['my_engine']
+              }
+            )
+          end
+
+          it 'does not add any offenses' do
+            expect_no_offenses(source, engine_file)
+          end
+        end
+      end
+    end
+
     context 'nested global model' do
       describe 'access of global model from engine' do
         let(:source) do

--- a/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
+++ b/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::FactoryBotUsage do
+  let(:test_cop) do
+    Class.new do
+      include RuboCop::Cop::FactoryBotUsage
+    end
+  end
+
+  describe '#find_factories' do
+    subject(:factories) { test_cop.new.find_factories(ast) }
+
+    let(:ast) do
+      source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
+      source.ast
+    end
+
+    let(:source_code) do
+      <<~'RUBY'
+        module NetworkEngine
+          FactoryBot.define do
+            sequence :port_name do |n|
+              "Test Port ##{n}"
+            end
+
+            # Model class defined explicitly
+            factory :port, class: ::NetworkEngine::Port do
+              port_name { FactoryBot.generate(:port_name) }
+              iata_code { nil }
+              airport { false }
+
+              # Model class derived from parent factory
+              factory :airport, aliases: [:airfield] do
+                airport { true }
+
+                factory :lax do
+                  iata_code { "LAX" }
+                end
+              end
+            end
+
+            # Implicit model class
+            factory :terminal
+
+            # Model class defined as string
+            factory :warehouse, class: "WarehouseEngine::Warehouse"
+          end
+        end
+      RUBY
+    end
+
+    it 'returns [factory_name, model_class_name] 2-tuples' do
+      expect(factories).to contain_exactly(
+        [:port, 'NetworkEngine::Port'],
+        [:airport, 'NetworkEngine::Port'],
+        [:airfield, 'NetworkEngine::Port'],
+        [:lax, 'NetworkEngine::Port'],
+        [:terminal, 'Terminal'],
+        [:warehouse, 'WarehouseEngine::Warehouse']
+      )
+    end
+  end
+end


### PR DESCRIPTION
To achieve true engine isolation, you have to ensure that your engine's test suite doesn't depend on other engines. It's easy to use a FactoryBot factory defined in another engine to create test fixtures. Our rubocop cops don't currently catch this.

This pull request updates the `EngineApiBoundary` and `GlobalModelAccessFromEngine` cops to detect cross-engine FactoryBot usage. If you use a factory defined in another engine - or a global factory - in your engine's specs, rubocop will complain. See https://github.flexport.io/flexport/flexport/pull/82483 for an example. Output: https://buildkite.com/organizations/flexport-1/pipelines/pr-tests/builds/233214/jobs/29abe3fa-67ec-452c-9652-52c84a0f8914/artifacts/60c347b9-e285-49b4-965f-3e0c2c58348d.

This is implemented by searching for all factory definition files, parsing them, extracting the names of each factory, and grouping them by engine. If you call `build`, `build_list`, `create`, or `create_list` in your specs, the linter will check that the factory you are trying to use was defined in your engine. If not, it will shout at you.

You can disable this behavior for your engine by adding it to `AllowCrossEngineFactoryBotFromEngines` for the `EngineApiBoundary` cop, and `AllowGlobalFactoryBotFromEngines` for the `GlobalModelAccessFromEngine` cop, in .rubocop.yml.