### PR TITLE
Add support for FactoryBot `parent` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## master (unreleased)
 
+## 0.10.1
+
+- Correctly determines the model class name of FactoryBot factories defined with
+  an explicit `parent` parameter.
+
 ## 0.10.0
 
-- EngineApiBoundary cop detects cross-engine use of FactoryBoy factories.
-- GlobalModelAccessFromEngine cop detects use of global FactoryBoy factories.
+- EngineApiBoundary cop detects cross-engine use of FactoryBot factories.
+- GlobalModelAccessFromEngine cop detects use of global FactoryBot factories.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Correctly determines the model class name of FactoryBot factories defined with
   an explicit `parent` parameter.
+- Disable FactoryBot detection by default.
 
 ## 0.10.0
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ Flexport/EngineApiBoundary:
   UnprotectedEngines: []
   StronglyProtectedEngines: []
   EngineSpecificOverrides: []
+  FactoryBotEnabled: false
   FactoryBotOutboundAccessAllowedEngines: []
 
 Flexport/GlobalModelAccessFromEngine:
@@ -17,6 +18,7 @@ Flexport/GlobalModelAccessFromEngine:
   GlobalModelsPath: app/models/
   DisabledEngines: []
   AllowedGlobalModels: []
+  FactoryBotEnabled: false
   FactoryBotGlobalAccessAllowedEngines: []
   Include:
     - '**/*.rb'

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ Flexport/EngineApiBoundary:
   UnprotectedEngines: []
   StronglyProtectedEngines: []
   EngineSpecificOverrides: []
+  AllowCrossEngineFactoryBotFromEngines: []
 
 Flexport/GlobalModelAccessFromEngine:
   Description: 'Do not directly access global models from within Rails Engines.'
@@ -16,6 +17,7 @@ Flexport/GlobalModelAccessFromEngine:
   GlobalModelsPath: app/models/
   DisabledEngines: []
   AllowedGlobalModels: []
+  AllowGlobalFactoryBotFromEngines: []
   Include:
     - '**/*.rb'
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,7 +6,7 @@ Flexport/EngineApiBoundary:
   UnprotectedEngines: []
   StronglyProtectedEngines: []
   EngineSpecificOverrides: []
-  AllowCrossEngineFactoryBotFromEngines: []
+  FactoryBotOutboundAccessAllowedEngines: []
 
 Flexport/GlobalModelAccessFromEngine:
   Description: 'Do not directly access global models from within Rails Engines.'
@@ -17,7 +17,7 @@ Flexport/GlobalModelAccessFromEngine:
   GlobalModelsPath: app/models/
   DisabledEngines: []
   AllowedGlobalModels: []
-  AllowGlobalFactoryBotFromEngines: []
+  FactoryBotGlobalAccessAllowedEngines: []
   Include:
     - '**/*.rb'
 

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -43,7 +43,7 @@ module RuboCop
       #
       # The cop will complain if you use FactoryBot factories defined in other
       # engines in your engine's specs. You can disable this check by adding
-      # the engine name to `AllowCrossEngineFactoryBotFromEngines` in
+      # the engine name to `FactoryBotOutboundAccessAllowedEngines` in
       # .rubocop.yml.
       #
       # # Isolation guarantee
@@ -430,13 +430,13 @@ module RuboCop
           strongly_protected_engines.include?(engine)
         end
 
-        def allow_cross_engine_factory_bot_from_engines
-          @allow_cross_engine_factory_bot_from_engines ||=
-            camelize_all(cop_config['AllowCrossEngineFactoryBotFromEngines'] || [])
+        def factory_bot_outbound_access_allowed_engines
+          @factory_bot_outbound_access_allowed_engines ||=
+            camelize_all(cop_config['FactoryBotOutboundAccessAllowedEngines'] || [])
         end
 
         def check_for_cross_engine_factory_bot?
-          spec_file? && !allow_cross_engine_factory_bot_from_engines.include?(current_engine)
+          spec_file? && !factory_bot_outbound_access_allowed_engines.include?(current_engine)
         end
 
         # Maps factories to the engine where they are defined.

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -214,7 +214,7 @@ module RuboCop
         def check_for_cross_engine_factory_bot_usage(node, factory_node)
           factory = factory_node.children[0]
           accessed_engine, model_class_name = factory_engines[factory]
-          return if accessed_engine.nil?
+          return if accessed_engine.nil? || !protected_engines.include?(accessed_engine)
 
           model_class_node = parse_ast(model_class_name)
           return if valid_engine_access?(model_class_node, accessed_engine)

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -168,10 +168,6 @@ module RuboCop
           (send _ {:belongs_to :has_one :has_many} sym $hash)
         PATTERN
 
-        class << self
-          attr_accessor :factory_engines_cache
-        end
-
         def on_const(node)
           return if in_module_or_class_declaration?(node)
           # There might be value objects that are named
@@ -447,9 +443,7 @@ module RuboCop
 
         # Maps factories to the engine where they are defined.
         def factory_engines
-          # Cache factories at the class level so that we don't have to fetch
-          # them again for every file we lint.
-          self.class.factory_engines_cache ||= find_factories.each_with_object({}) do |factory_file, h|
+          @factory_engines ||= find_factories.each_with_object({}) do |factory_file, h|
             path, factories = factory_file
             engine_name = engine_name_from_path(path)
             factories.each do |factory, model_class_name|

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -435,8 +435,14 @@ module RuboCop
             camelize_all(cop_config['FactoryBotOutboundAccessAllowedEngines'] || [])
         end
 
+        def factory_bot_enabled?
+          cop_config['FactoryBotEnabled']
+        end
+
         def check_for_cross_engine_factory_bot?
-          spec_file? && !factory_bot_outbound_access_allowed_engines.include?(current_engine)
+          spec_file? &&
+            factory_bot_enabled? &&
+            !factory_bot_outbound_access_allowed_engines.include?(current_engine)
         end
 
         # Maps factories to the engine where they are defined.

--- a/lib/rubocop/cop/flexport/engine_api_boundary.rb
+++ b/lib/rubocop/cop/flexport/engine_api_boundary.rb
@@ -443,21 +443,17 @@ module RuboCop
         def factory_engines
           # Cache factories at the class level so that we don't have to fetch
           # them again for every file we lint.
-          self.class.factory_engines_cache ||= spec_factory_paths.each_with_object({}) do |path, h|
+          self.class.factory_engines_cache ||= find_factories.each_with_object({}) do |factory_file, h|
+            path, factories = factory_file
             engine_name = engine_name_from_path(path)
-            ast = parse_ast(File.read(path))
-            find_factories(ast).each do |factory, model_class_name|
+            factories.each do |factory, model_class_name|
               h[factory] = [engine_name, model_class_name]
             end
           end
         end
 
-        def spec_factory_paths
-          @spec_factory_paths ||= Dir["#{engines_path}*/spec/factories/**/*.rb"]
-        end
-
         def spec_factories_modified_time_checksum
-          mtimes = spec_factory_paths.sort.map { |f| File.mtime(f) }
+          mtimes = factory_files.sort.map { |f| File.mtime(f) }
           Digest::SHA1.hexdigest(mtimes.join)
         end
       end

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -47,7 +47,7 @@ module RuboCop
       #
       # This cop will also complain if you try to use global FactoryBot
       # factories in your engine's specs. To disable this behavior for your
-      # engine, add it to the `AllowGlobalFactoryBotFromEngines` list in
+      # engine, add it to the `FactoryBotGlobalAccessAllowedEngines` list in
       # .rubocop.yml.
       #
       class GlobalModelAccessFromEngine < Cop
@@ -173,7 +173,7 @@ module RuboCop
         end
 
         def check_for_global_factory_bot?
-          spec_file? && allow_global_factory_bot_from_engines.none? do |engine|
+          spec_file? && factory_bot_global_access_allowed_engines.none? do |engine|
             processed_source.path.include?(File.join(engines_path, engine, ''))
           end
         end
@@ -214,8 +214,8 @@ module RuboCop
           end
         end
 
-        def allow_global_factory_bot_from_engines
-          cop_config['AllowGlobalFactoryBotFromEngines'] || []
+        def factory_bot_global_access_allowed_engines
+          cop_config['FactoryBotGlobalAccessAllowedEngines'] || []
         end
 
         def allowed_global_models

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -61,10 +61,6 @@ module RuboCop
           (send _ {:belongs_to :has_one :has_many} sym $hash)
         PATTERN
 
-        class << self
-          attr_accessor :global_factories_cache
-        end
-
         def on_const(node)
           return unless in_enforced_engine_file?
           return unless global_model_const?(node)
@@ -127,9 +123,7 @@ module RuboCop
         end
 
         def global_factories
-          # Cache factories at the class level so that we don't have to fetch
-          # them again for every file we lint.
-          self.class.global_factories_cache ||=
+          @global_factories ||=
             find_factories.reject { |path| path.start_with?(engines_path) }.values.reduce(:merge)
         end
 

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -129,21 +129,12 @@ module RuboCop
         def global_factories
           # Cache factories at the class level so that we don't have to fetch
           # them again for every file we lint.
-          self.class.global_factories_cache ||= spec_factory_paths.each_with_object({}) do |path, h|
-            source_code = File.read(path)
-            source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
-            find_factories(source.ast).each do |factory, model_class_name|
-              h[factory] = model_class_name
-            end
-          end
+          self.class.global_factories_cache ||=
+            find_factories.reject { |path| path.start_with?(engines_path) }.values.reduce(:merge)
         end
 
         def model_dir_paths
           Dir[File.join(global_models_path, '**/*.rb')]
-        end
-
-        def spec_factory_paths
-          @spec_factory_paths ||= Dir['spec/factories/**/*.rb']
         end
 
         def calculate_global_models

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -173,7 +173,7 @@ module RuboCop
         end
 
         def check_for_global_factory_bot?
-          spec_file? && factory_bot_global_access_allowed_engines.none? do |engine|
+          spec_file? && factory_bot_enabled? && factory_bot_global_access_allowed_engines.none? do |engine|
             processed_source.path.include?(File.join(engines_path, engine, ''))
           end
         end
@@ -216,6 +216,10 @@ module RuboCop
 
         def factory_bot_global_access_allowed_engines
           cop_config['FactoryBotGlobalAccessAllowedEngines'] || []
+        end
+
+        def factory_bot_enabled?
+          cop_config['FactoryBotEnabled']
         end
 
         def allowed_global_models

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -9,7 +9,7 @@ module RuboCop
     module FactoryBotUsage
       extend NodePattern::Macros
 
-      Factory = Struct.new('Factory', :name, :aliases, :parent, :model_class_name, keyword_init: true)
+      Factory = Struct.new('Factory', :name, :aliases, :parent, :model_class_name)
 
       FACTORY_BOT_METHODS = %i[
         attributes_for
@@ -129,12 +129,12 @@ module RuboCop
       def parse_factory_node(node)
         factory_name_node, factory_config_node = node.children[2..3]
 
-        Factory.new(
-          name: factory_name_node.children[0],
-          aliases: extract_aliases(factory_config_node),
-          parent: extract_parent(factory_config_node),
-          model_class_name: extract_model_class_name(factory_config_node)
-        )
+        name = factory_name_node.children[0]
+        aliases = extract_aliases(factory_config_node)
+        parent = extract_parent(factory_config_node)
+        model_class_name = extract_model_class_name(factory_config_node)
+
+        Factory.new(name, aliases, parent, model_class_name)
       end
 
       def extract_aliases(factory_config_hash_node)

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.10.0'
+    VERSION = '0.10.1'
   end
 end

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -415,7 +415,7 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
         let(:config_params) do
           {
             'EnginesPath' => 'engines',
-            'AllowCrossEngineFactoryBotFromEngines' => ['my_engine']
+            'FactoryBotOutboundAccessAllowedEngines' => ['my_engine']
           }
         end
 

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
       # them again for every file. Clear the cache after each test to ensure we
       # run each test with a clean slate.
       after do
-        described_class.factory_engines_cache = nil
+        RuboCop::Cop::FactoryBotUsage.factories_cache = nil
       end
 
       context 'when file is not a spec' do

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -423,6 +423,19 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
           expect_no_offenses(source, file_path)
         end
       end
+
+      context 'when engine is unprotected' do
+        let(:config_params) do
+          {
+            'EnginesPath' => 'engines',
+            'UnprotectedEngines' => ['other_engine']
+          }
+        end
+
+        it 'does not add any offenses' do
+          expect_no_offenses(source, file_path)
+        end
+      end
     end
   end
 

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -337,7 +337,7 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
       before do
         allow(Dir)
           .to receive(:[])
-          .with('engines/*/spec/factories/**/*.rb')
+          .with(a_string_matching(/factories/))
           .and_return([factory_path])
         allow(File)
           .to receive(:read)

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -333,6 +333,12 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
           create(:port)
         RUBY
       end
+      let(:config_params) do
+        {
+          'EnginesPath' => 'engines',
+          'FactoryBotEnabled' => true
+        }
+      end
 
       before do
         allow(Dir)
@@ -429,6 +435,19 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
           {
             'EnginesPath' => 'engines',
             'UnprotectedEngines' => ['other_engine']
+          }
+        end
+
+        it 'does not add any offenses' do
+          expect_no_offenses(source, file_path)
+        end
+      end
+
+      context 'when feature is disabled' do
+        let(:config_params) do
+          {
+            'EnginesPath' => 'engines',
+            'FactoryBotEnabled' => false
           }
         end
 

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
               'Flexport/GlobalModelAccessFromEngine' => {
                 'EnginesPath' => 'engines',
                 'GlobalModelsPath' => 'app/models/',
-                'AllowGlobalFactoryBotFromEngines' => ['my_engine']
+                'FactoryBotGlobalAccessAllowedEngines' => ['my_engine']
               }
             )
           end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
       # them again for every file. Clear the cache after each test to ensure we
       # run each test with a clean slate.
       after do
-        described_class.global_factories_cache = nil
+        RuboCop::Cop::FactoryBotUsage.factories_cache = nil
       end
 
       context 'when file is not a spec' do

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
       before do
         allow(Dir)
           .to receive(:[])
-          .with('spec/factories/**/*.rb')
+          .with(a_string_matching(/factories/))
           .and_return([factory_path])
         allow(File)
           .to receive(:read)

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -200,6 +200,15 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
           create(:port)
         RUBY
       end
+      let(:config) do
+        RuboCop::Config.new(
+          'Flexport/GlobalModelAccessFromEngine' => {
+            'EnginesPath' => 'engines',
+            'GlobalModelsPath' => 'app/models/',
+            'FactoryBotEnabled' => true
+          }
+        )
+      end
 
       before do
         allow(Dir)
@@ -248,6 +257,22 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
                 'EnginesPath' => 'engines',
                 'GlobalModelsPath' => 'app/models/',
                 'FactoryBotGlobalAccessAllowedEngines' => ['my_engine']
+              }
+            )
+          end
+
+          it 'does not add any offenses' do
+            expect_no_offenses(source, engine_file)
+          end
+        end
+
+        context 'when feature is disabled' do
+          let(:config) do
+            RuboCop::Config.new(
+              'Flexport/GlobalModelAccessFromEngine' => {
+                'EnginesPath' => 'engines',
+                'GlobalModelsPath' => 'app/models/',
+                'FactoryBotEnabled' => false
               }
             )
           end

--- a/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
+++ b/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
@@ -4,20 +4,19 @@ RSpec.describe RuboCop::Cop::FactoryBotUsage do
   let(:test_cop) do
     Class.new do
       include RuboCop::Cop::FactoryBotUsage
+
+      def engines_path
+        'engines/'
+      end
     end
   end
 
   describe '#find_factories' do
-    subject(:factories) { test_cop.new.find_factories(ast) }
+    subject(:factories) { test_cop.new.find_factories }
 
-    let(:ast) do
-      source = RuboCop::ProcessedSource.new(source_code, RUBY_VERSION.to_f)
-      source.ast
-    end
-
-    let(:source_code) do
-      <<~'RUBY'
-        module NetworkEngine
+    let(:factory_files) do
+      {
+        'engines/network_engine/spec/factories/port_factories.rb' => <<~'RUBY',
           FactoryBot.define do
             sequence :port_name do |n|
               "Test Port ##{n}"
@@ -38,25 +37,64 @@ RSpec.describe RuboCop::Cop::FactoryBotUsage do
                 end
               end
             end
-
-            # Implicit model class
-            factory :terminal
-
-            # Model class defined as string
-            factory :warehouse, class: "WarehouseEngine::Warehouse"
           end
-        end
-      RUBY
+        RUBY
+        'spec/factories/warehouse_factories.rb' => <<~'RUBY',
+          FactoryBot.define do
+            # Model class defined as string
+            factory :warehouse, parent: :location, class: "WarehouseEngine::Warehouse"
+          end
+        RUBY
+        'spec/factories/cfs_factories.rb' => <<~'RUBY',
+          FactoryBot.define do
+            # Explicit parent
+            factory :cfs, parent: :location do
+              factory :flexport_cfs
+            end
+
+            factory :flexport_chicago_cfs, parent: :flexport_cfs
+          end
+        RUBY
+        'spec/factories/location_factories.rb' => <<~'RUBY'
+          FactoryBot.define do
+            # Implicit model class derived from factory name
+            factory :location
+          end
+        RUBY
+      }
+    end
+    let(:engine_factory_paths) do
+      factory_files.keys.select { |path| path.start_with?('engines/') }
+    end
+    let(:global_factory_paths) do
+      factory_files.keys - engine_factory_paths
     end
 
-    it 'returns [factory_name, model_class_name] 2-tuples' do
-      expect(factories).to contain_exactly(
-        [:port, 'NetworkEngine::Port'],
-        [:airport, 'NetworkEngine::Port'],
-        [:airfield, 'NetworkEngine::Port'],
-        [:lax, 'NetworkEngine::Port'],
-        [:terminal, 'Terminal'],
-        [:warehouse, 'WarehouseEngine::Warehouse']
+    before do
+      allow(Dir).to receive(:[]).with('spec/factories/**/*.rb').and_return(global_factory_paths)
+      allow(Dir).to receive(:[]).with('engines/*/spec/factories/**/*.rb').and_return(engine_factory_paths)
+      allow(File).to receive(:read) { |path| factory_files.fetch(path) }
+    end
+
+    it 'returns a mapping of factory names to model class names' do
+      expect(factories).to eq(
+        'engines/network_engine/spec/factories/port_factories.rb' => {
+          port: 'NetworkEngine::Port',
+          airport: 'NetworkEngine::Port',
+          airfield: 'NetworkEngine::Port',
+          lax: 'NetworkEngine::Port'
+        },
+        'spec/factories/warehouse_factories.rb' => {
+          warehouse: 'WarehouseEngine::Warehouse'
+        },
+        'spec/factories/cfs_factories.rb' => {
+          cfs: 'Location',
+          flexport_cfs: 'Location',
+          flexport_chicago_cfs: 'Location'
+        },
+        'spec/factories/location_factories.rb' => {
+          location: 'Location'
+        }
       )
     end
   end

--- a/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
+++ b/spec/rubocop/cop/mixin/factory_bot_usage_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe RuboCop::Cop::FactoryBotUsage do
     end
   end
 
+  after do
+    described_class.factories_cache = nil
+  end
+
   describe '#find_factories' do
     subject(:factories) { test_cop.new.find_factories }
 


### PR DESCRIPTION
Follow-up to https://github.com/flexport/rubocop-flexport/pull/21.

FactoryBot provides two ways for factories to "inherit" properties from a parent:

1. Nesting within the parent factory:
    ```ruby
    factory :port do
      factory :airport
    end
    ```
2. The `parent` attribute:
    ```ruby
    factory :port
    factory :airport, parent: :port
    ```

https://github.com/flexport/rubocop-flexport/pull/21 handles nesting, but not the `parent` attribute. This pull request adds support for the `parent` attribute, allowing cops to correctly determine the model class name for every factory. This in turn allows these cops to work as expected with the existing configuration files (allowlists, .rubocop.yml).