### PR TITLE
Make factory_bot_usage matcher match factory calls with additional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+## 0.10.2
+
+- Updates factory_bot_usage matcher to match factory calls with additional arguments
+
 ## 0.10.1
 
 - Correctly determines the model class name of FactoryBot factories defined with

--- a/lib/rubocop/cop/mixin/factory_bot_usage.rb
+++ b/lib/rubocop/cop/mixin/factory_bot_usage.rb
@@ -25,7 +25,7 @@ module RuboCop
       ].freeze
 
       def_node_matcher :factory_bot_usage, <<~PATTERN
-        (send _ {#{FACTORY_BOT_METHODS.map(&:inspect).join(' ')}} $sym)
+        (send _ {#{FACTORY_BOT_METHODS.map(&:inspect).join(' ')}} $sym ...)
       PATTERN
 
       # Cache factories at the class level so that we don't have to fetch them

--- a/lib/rubocop/flexport/version.rb
+++ b/lib/rubocop/flexport/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Flexport
-    VERSION = '0.10.1'
+    VERSION = '0.10.2'
   end
 end

--- a/rubocop-flexport.gemspec
+++ b/rubocop-flexport.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'rubocop', '>= 0.70.0'
+
+  spec.required_ruby_version = '>= 2.4'
 end

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -387,6 +387,19 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
         end
       end
 
+      context 'when factory is defined in other engine and an argument is passed to the factory' do
+        let(:source) do
+          <<~RUBY
+            create(:port, name: "Seattle")
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
+          RUBY
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, file_path)
+        end
+      end
+
       context "when model is in other engine's allowlist" do
         let(:allowlist_source) do
           <<~RUBY

--- a/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
+++ b/spec/rubocop/cop/flexport/engine_api_boundary_spec.rb
@@ -375,28 +375,46 @@ RSpec.describe RuboCop::Cop::Flexport::EngineApiBoundary do
       end
 
       context 'when factory is defined in other engine' do
-        let(:source) do
-          <<~RUBY
-            create(:port)
-            ^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
-          RUBY
+        context 'and no additional arguments are passed to the factory' do
+          let(:source) do
+            <<~RUBY
+              create(:port)
+              ^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
+            RUBY
+          end
+
+          it 'adds an offense' do
+            expect_offense(source, file_path)
+          end
         end
 
-        it 'adds an offense' do
-          expect_offense(source, file_path)
-        end
-      end
+        context 'and one additional argument is passed to the factory' do
+          let(:source) do
+            <<~RUBY
+              create(:port, name: "Seattle")
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
+            RUBY
+          end
 
-      context 'when factory is defined in other engine and an argument is passed to the factory' do
-        let(:source) do
-          <<~RUBY
-            create(:port, name: "Seattle")
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
-          RUBY
+          it 'adds an offense' do
+            expect_offense(source, file_path)
+          end
         end
 
-        it 'adds an offense' do
-          expect_offense(source, file_path)
+        context 'and multiple arguments are passed to the factory' do
+          let(:source) do
+            <<~RUBY
+              create(:port,
+              ^^^^^^^^^^^^^ Direct access of OtherEngine engine. Only access engine via OtherEngine::Api.
+                name: "Seattle",
+                country_code: "US",
+              )
+            RUBY
+          end
+
+          it 'adds an offense' do
+            expect_offense(source, file_path)
+          end
         end
       end
 


### PR DESCRIPTION
The `factory_bot_usage` node matcher currently only matches calls to the factory bot methods which pass the name of the factory and no other arguments. 

Tested via the spec, and by running this version of rubocop on a file in our main repo which had cross engine factory calls that weren't caught before and now are.