### PR TITLE
Provide config for additional global models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea
 /.yardoc
 /_yardoc/
 /coverage/

--- a/config/default.yml
+++ b/config/default.yml
@@ -18,6 +18,7 @@ Flexport/GlobalModelAccessFromEngine:
   GlobalModelsPath: app/models/
   DisabledEngines: []
   AllowedGlobalModels: []
+  AdditionalGlobalModels: []
   FactoryBotEnabled: false
   FactoryBotGlobalAccessAllowedEngines: []
   Include:

--- a/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
+++ b/lib/rubocop/cop/flexport/global_model_access_from_engine.rb
@@ -140,7 +140,7 @@ module RuboCop
             file_name = path.gsub(global_models_path, '').gsub('.rb', '')
             ActiveSupport::Inflector.classify(file_name)
           end
-          all_models - allowed_global_models
+          all_models - allowed_global_models + additional_global_models
         end
 
         def extract_class_name_node(assocation_hash_args)
@@ -218,6 +218,10 @@ module RuboCop
 
         def allowed_global_models
           cop_config['AllowedGlobalModels'] || []
+        end
+
+        def additional_global_models
+          cop_config['AdditionalGlobalModels'] || []
         end
       end
     end

--- a/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
+++ b/spec/rubocop/cop/flexport/global_model_access_from_engine_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
         ],
         'EnginesPath' => 'engines',
         'GlobalModelsPath' => 'app/models/',
-        'AllowedGlobalModels' => ['WhitelistedGlobalModel']
+        'AllowedGlobalModels' => ['WhitelistedGlobalModel'],
+        'AdditionalGlobalModels' => ['AnotherGlobalModel']
       }
     )
   end
@@ -153,6 +154,29 @@ RSpec.describe RuboCop::Cop::Flexport::GlobalModelAccessFromEngine, :config do
         <<~RUBY
           SomeGlobalModel.find(123)
           ^^^^^^^^^^^^^^^ Direct access of global model `SomeGlobalModel` from within Rails Engine.
+        RUBY
+      end
+
+      it 'adds an offense' do
+        expect_offense(source, engine_file)
+      end
+
+      context "an engine's name has a prefix that matches a disabled engine" do
+        let(:engine_file) do
+          '/root/engines/fake_disabled_engine_foo/app/file.rb'
+        end
+
+        it 'adds an offense' do
+          expect_offense(source, engine_file)
+        end
+      end
+    end
+
+    describe 'access of global model on the additional model list from engine' do
+      let(:source) do
+        <<~RUBY
+          AnotherGlobalModel.find(123)
+          ^^^^^^^^^^^^^^^^^^ Direct access of global model `AnotherGlobalModel` from within Rails Engine.
         RUBY
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,12 @@ RSpec.configure do |config|
   config.raise_errors_for_deprecations!
   config.raise_on_warning = true
   config.fail_if_no_examples = true
+  config.before(:each) do
+    allow(File)
+      .to receive(:read)
+      .with(a_string_matching("/obsoletion.yml"))
+      .and_call_original
+  end
 
   config.order = :random
   Kernel.srand config.seed


### PR DESCRIPTION
Currently, we only look at global models from a single directory. However, as we are modularizing monolith models using packwerk, they may be distributed in multiple directories.

This pr introduces `AdditionalGlobalModels` config, so models outside of the `app/models` directory can also be treated as global models by this rubocop.